### PR TITLE
Fix JMX profile

### DIFF
--- a/profiles/artemis/_modules/artemis_profile/default_jmx.yaml.jinja2
+++ b/profiles/artemis/_modules/artemis_profile/default_jmx.yaml.jinja2
@@ -22,8 +22,6 @@ artemis_profile:
     - -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload
     - -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml
   java_args_run:
-    - -Dcom.sun.management.jmxremote=true
-    - -Dcom.sun.management.jmxremote.port=1099
     - -Dcom.sun.management.jmxremote.rmi.port=1099
     - -Dcom.sun.management.jmxremote.local.only=false
     - -Dcom.sun.management.jmxremote.ssl=false

--- a/profiles/artemis/_modules/management_xml/unauthenticated_connector.yaml.jinja2
+++ b/profiles/artemis/_modules/management_xml/unauthenticated_connector.yaml.jinja2
@@ -1,0 +1,47 @@
+management_xml:
+  connector:
+    host: 0.0.0.0
+    port: 1099
+    authenticator_type: NONE
+  whitelist:
+  - domain: '*'
+  default_access:
+    - method: 'list*'
+      roles:
+      - amq
+    - method: 'get*'
+      roles:
+      - amq
+    - method: 'is*'
+      roles:
+      - amq
+    - method: 'set*'
+      roles:
+      - amq
+    - method: '*'
+      roles:
+      - amq
+  role_access:
+    - domain: org.apache.activemq.artemis
+      access:
+      - method: 'list*'
+        roles:
+        - amq
+      - method: 'get*'
+        roles:
+        - amq
+      - method: 'is*'
+        roles:
+        - amq
+      - method: 'set*'
+        roles:
+        - amq
+      - method: 'browse*'
+        roles:
+        - amq
+      - method: 'count*'
+        roles:
+        - amq
+      - method: '*'
+        roles:
+        - amq


### PR DESCRIPTION
Fix the jmx profile to include a profile which allows unauthenticated jmx connection and modify the artemis.profile profile to remove unneeded jmx java options to allow the control to be in management.xml

- add unauthenticated jmx connector profile
- fix defaul_jmx  artemis.profile profile