### PR TITLE
Enhance ha/cluster profiles/templates with updates

### DIFF
--- a/profiles/artemis/_modules/broker_xml/broadcast_groups/user_broadcast_groups.yaml.jinja2
+++ b/profiles/artemis/_modules/broker_xml/broadcast_groups/user_broadcast_groups.yaml.jinja2
@@ -2,21 +2,11 @@
   broadcast_groups:
     {% for broadcast_group in user_broadcast_groups %}
     - name: '{{ broadcast_group.name }}'
-      {% if broadcast_group.local_bind_address is defined %}
-      local_bind_address: '{{ broadcast_group.local_bind_address }}'
-      {% endif %}
-      {% if broadcast_group.local_bind_port is defined %}
-      local_bind_port: '{{ broadcast_group.local_bind_port }}'
-      {% endif %}
-      {% if broadcast_group.group_address is defined %}
-      group_address: '{{ broadcast_group.group_address }}'
-      {% endif %}
-      {% if broadcast_group.group_port is defined %}
-      group_port: '{{ broadcast_group.group_port }}'
-      {% endif %}
-      {% if broadcast_group.broadcast_period is defined %}
-      broadcast_period: '{{ broadcast_group.broadcast_period }}'
-      {% endif %}
+      local_bind_address: '{{ broadcast_group.local_bind_address | default(broker_name) }}'
+      local_bind_port: '{{ broadcast_group.local_bind_port | default('-1') }}'
+      group_address: '{{ broadcast_group.group_address | default('231.7.7.7') }}'
+      group_port: '{{ broadcast_group.group_port | default('9876') }}'
+      broadcast_period: '{{ broadcast_group.broadcast_period | default('2000') }}'
       {% if broadcast_group.jgroups_file is defined %}
       jgroups_file: '{{ broadcast_group.jgroups_file }}'
       {% endif %}

--- a/profiles/artemis/_modules/broker_xml/cluster_connections/user_cluster_connections.yaml.jinja2
+++ b/profiles/artemis/_modules/broker_xml/cluster_connections/user_cluster_connections.yaml.jinja2
@@ -4,12 +4,8 @@
     {% for connection in user_cluster_connections %}
     - name: '{{ connection.name }}'
       connector_ref: '{{ connection.connector_ref }}'
-      {% if connection.check_period is defined %}
-      check_period: '{{ connection.check_period }}'
-      {% endif %}
-      {% if connection.connection_ttl is defined %}
-      connection_ttl: '{{ connection.connection_ttl }}'
-      {% endif %}
+      check_period: '{{ connection.check_period | default('1000') }}'
+      connection_ttl: '{{ connection.connection_ttl | default('5000') }}'
       {% if connection.message_load_balancing is defined %}
       message_load_balancing: '{{ connection.message_load_balancing }}'
       {% endif %}

--- a/profiles/artemis/_modules/broker_xml/connectors/user_connectors.yaml.jinja2
+++ b/profiles/artemis/_modules/broker_xml/connectors/user_connectors.yaml.jinja2
@@ -3,7 +3,7 @@
     {% for connector in user_connectors %}
     - name: '{{ connector.name }}'
       protocol: '{{ connector.protocol |  default('tcp') }}'
-      address: '{{ connector.address |  default('0.0.0.0') }}'
+      address: '{{ connector.address | default(broker_name) }}'
       port: '{{ connector.port |  default('61616') }}'
       {% if connector.properties is defined %}
       properties:

--- a/profiles/artemis/_modules/broker_xml/discovery_groups/user_discovery_groups.yaml.jinja2
+++ b/profiles/artemis/_modules/broker_xml/discovery_groups/user_discovery_groups.yaml.jinja2
@@ -2,27 +2,17 @@
   discovery_groups:
     {% for discovery_group in user_discovery_groups %}
     - name: '{{ discovery_group.name }}'
-      {% if discovery_group.group_address is defined %}
-      group_address: '{{ discovery_group.group_address }}'
-      {% endif %}
-      {% if discovery_group.group_port is defined %}
-      group_port: '{{ discovery_group.group_port }}'
-      {% endif %}
+      group_address: '{{ discovery_group.group_address | default('231.7.7.7') }}'
+      group_port: '{{ discovery_group.group_port | default('9876') }}'
       {% if discovery_group.jgroups_file is defined %}
       jgroups_file: '{{ discovery_group.jgroups_file }}'
       {% endif %}
       {% if discovery_group.jgroups_channel is defined %}
       jgroups_channel: '{{ discovery_group.jgroups_channel }}'
       {% endif %}
-      {% if discovery_group.refresh_timeout is defined %}
-      refresh_timeout: '{{ discovery_group.refresh_timeout }}'
-      {% endif %}
-      {% if discovery_group.local_bind_address is defined %}
-      local_bind_address: '{{ discovery_group.local_bind_address }}'
-      {% endif %}
-      {% if discovery_group.local_bind_port is defined %}
-      local_bind_port: '{{ discovery_group.local_bind_port }}'
-      {% endif %}
+      refresh_timeout: '{{ discovery_group.refresh_timeout | default('10000') }}'
+      local_bind_address: '{{ discovery_group.local_bind_address | default(broker_name) }}'
+      local_bind_port: '{{ discovery_group.local_bind_port | default('-1') }}'
       {% if discovery_group.initial_wait_timeout is defined %}
       initial_wait_timeout: '{{ discovery_group.initial_wait_timeout }}'
       {% endif %}

--- a/profiles/artemis/_modules/broker_xml/ha_policy/user_ha_policy.yaml.jinja2
+++ b/profiles/artemis/_modules/broker_xml/ha_policy/user_ha_policy.yaml.jinja2
@@ -1,0 +1,96 @@
+{% if user_ha is defined %}
+  ha_policy:
+  {% if user_ha.policy is defined and user_ha.policy == 'shared-store' %}
+    - policy: shared-store
+    {% if user_ha.role is defined and user_ha.role == 'master' %}
+      role: master
+      {% if user_ha.properties is defined %}
+      properties:
+        {% if user_ha.properties.failover_on_shutdown is defined %}
+        failover_on_shutdown: {{ user_ha.properties.failover_on_shutdown }}
+        {% endif %}
+        {% if user_ha.properties.wait_for_activation is defined %}
+        wait_for_activation: {{ user_ha.properties.wait_for_activation }}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+    {% if user_ha.role is defined and user_ha.role == 'slave' %}
+      role: slave
+      {% if user_ha.properties is defined %}
+      properties:
+        {% if user_ha.properties.allow_failback is defined %}
+        allow_failback: {{ user_ha.properties.allow_failback }}
+        {% endif %}
+        {% if user_ha.properties.failover_on_shutdown is defined %}
+        failover_on_shutdown: {{ user_ha.properties.failover_on_shutdown }}
+        {% endif %}
+        {% if user_ha.properties.restart_backup is defined %}
+        restart_backup: {{ user_ha.properties.restart_backup }}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+  {% if user_ha.policy is defined and user_ha.policy == 'replication' %}
+    - policy: replication
+    {% if user_ha.role is defined and user_ha.role == 'primary' %}
+      role: primary
+      {% if user_ha.properties is defined %}
+      properties:
+        {% if user_ha.properties.cluster_name is defined %}
+        cluster_name: {{ user_ha.properties.cluster_name }}
+        {% endif %}
+        {% if user_ha.properties.group_name is defined %}
+        group_name: {{ user_ha.properties.group_name }}
+        {% endif %}
+        {% if user_ha.properties.coordination_id is defined %}
+        coordination_id: {{ user_ha.properties.coordination_id }}
+        {% endif %}
+        {% if user_ha.properties.initial_replication_sync_timeout is defined %}
+        initial_replication_sync_timeout: {{ user_ha.properties.initial_replication_sync_timeout }}
+        {% endif %}
+        {% if user_ha.properties.retry_replication_wait is defined %}
+        retry_replication_wait: {{ user_ha.properties.retry_replication_wait }}
+        {% endif %}
+        {% if user_ha.properties.manager is defined %}
+        manager:
+          {% if user_ha.properties.manager.class_name is defined %}
+          class_name: {{ user_ha.properties.manager.class_name }}
+          {% endif %}
+          {% if user_ha.properties.manager.properties is defined %}
+          properties: {{ user_ha.properties.manager.properties }}
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+    {% if user_ha.role is defined and user_ha.role == 'backup' %}
+      role: backup
+      {% if user_ha.properties is defined %}
+      properties:
+        {% if user_ha.properties.cluster_name is defined %}
+        cluster_name: {{ user_ha.properties.cluster_name }}
+        {% endif %}
+        {% if user_ha.properties.group_name is defined %}
+        group_name: {{ user_ha.properties.group_name }}
+        {% endif %}
+        {% if user_ha.properties.initial_replication_sync_timeout is defined %}
+        initial_replication_sync_timeout: {{ user_ha.properties.initial_replication_sync_timeout }}
+        {% endif %}
+        {% if user_ha.properties.retry_replication_wait is defined %}
+        retry_replication_wait: {{ user_ha.properties.retry_replication_wait }}
+        {% endif %}
+        {% if user_ha.properties.allow_failback is defined %}
+        allow_failback: {{ user_ha.properties.allow_failback }}
+        {% endif %}
+        {% if user_ha.properties.manager is defined %}
+        manager:
+          {% if user_ha.properties.manager.class_name is defined %}
+          class_name: {{ user_ha.properties.manager.class_name }}
+          {% endif %}
+          {% if user_ha.properties.manager.properties is defined %}
+          properties: {{ user_ha.properties.manager.properties }}
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+{% endif %}

--- a/templates/artemis/modules/broker_xml/ha_policy/replication_slave.jinja2
+++ b/templates/artemis/modules/broker_xml/ha_policy/replication_slave.jinja2
@@ -24,9 +24,6 @@
                     {% if policy.properties.restart_backup is defined %}
                     <restart-backup>{{ policy.properties.restart_backup  }}</restart-backup>
                     {% endif %}
-                    {% if policy.properties.failback_delay is defined %}
-                    <failback-delay>{{ policy.properties.failback_delay  }}</failback-delay>
-                    {% endif %}
                     {% if policy.properties.quorum_size is defined %}
                     <quorum-size>{{ policy.properties.quorum_size  }}</quorum-size>
                     {% endif %}

--- a/templates/artemis/modules/broker_xml/ha_policy/shared_store_master.jinja2
+++ b/templates/artemis/modules/broker_xml/ha_policy/shared_store_master.jinja2
@@ -4,13 +4,10 @@
             {% else %}
                 <master>
                     {% if policy.properties.failover_on_server_shutdown is defined %}
-                    <failover-on-shutdown>{{ mbool(policy.properties.failover_on_shutdown)  }}</failover-on-shutdown>
+                    <failover-on-shutdown>{{ mbool(policy.properties.failover_on_shutdown) }}</failover-on-shutdown>
                     {% endif %}
                     {% if policy.properties.wait_for_activation is defined %}
-                    <wait-for-activation>{{ mbool(policy.properties.wait_for_activation)  }}</wait-for-activation>
-                    {% endif %}
-                    {% if policy.properties.failback_delay is defined %}
-                    <failback-delay>{{ mbool(policy.properties.failback_delay) }}</failback-delay>
+                    <wait-for-activation>{{ mbool(policy.properties.wait_for_activation) }}</wait-for-activation>
                     {% endif %}
                 </master>
             {% endif %}

--- a/templates/artemis/modules/broker_xml/ha_policy/shared_store_slave.jinja2
+++ b/templates/artemis/modules/broker_xml/ha_policy/shared_store_slave.jinja2
@@ -4,13 +4,10 @@
             {% else %}
                 <slave>
                     {% if policy.properties.failover_on_server_shutdown is defined %}
-                    <failover-on-shutdown>{{ mbool(policy.properties.failover_on_shutdown)  }}</failover-on-shutdown>
+                    <failover-on-shutdown>{{ mbool(policy.properties.failover_on_shutdown) }}</failover-on-shutdown>
                     {% endif %}
                     {% if policy.properties.allow_failback is defined %}
                     <allow-failback>{{ mbool(policy.properties.allow_failback) }}</allow-failback>
-                    {% endif %}
-                    {% if policy.properties.failback_delay is defined %}
-                    <failback-delay>{{ mbool(policy.properties.failback_delay) }}</failback-delay>
                     {% endif %}
                     {% if policy.properties.restart_backup is defined %}
                     <restart-backup>{{ mbool(policy.properties.restart_backup) }}</restart-backup>


### PR DESCRIPTION
This contains a small update for the ha templates with the removal of deprecated tag and add a new user_ha profile to be used to configure ha for share-store and replication.